### PR TITLE
minor mod that tweaks factions balance and adds start by factions ready

### DIFF
--- a/scripts/game/PS_GameModeQuickTvT.c
+++ b/scripts/game/PS_GameModeQuickTvT.c
@@ -166,7 +166,220 @@ class PS_GameModeQuickTvT : PS_GameModeCoop
 		}
 		GameStateTransitions.RequestScenarioChangeTransition(mission.MissionConfig, "");
 	}
+	
+	// 
+	// ------==========  partyzans great code start  =================----------
+	//
+	
+	// this changes balance script to allow players join faction at same ratio to avaivable human players as it has to overall playable units
+	override bool CanJoinFaction(FactionKey factionKeyPlayer, FactionKey currentFaction)
+	{
+		if (m_iFactionsBalance == -1)
+			return true;
+		if (factionKeyPlayer == currentFaction)
+			return true;
+		
+		map<FactionKey, int> players = new map<FactionKey, int>();
+		map<FactionKey, int> playables = new map<FactionKey, int>();
+		map<FactionKey, float> desiredratio = new map<FactionKey, float>();
+		array<PS_PlayableContainer> playableComponents = m_playableManager.GetPlayablesSorted();
+		
+		//counting avaivable slots
+		int playablesammount = 0;
+		foreach (PS_PlayableContainer playable : playableComponents)
+		{
+			playablesammount = playablesammount + 1;
+			FactionKey factionKey = playable.GetFactionKey();
+			if (!players.Contains(factionKey))
+				players[factionKey] = 0;
+			if (!playables.Contains(factionKey))
+				playables[factionKey] = 0;
+			
+			playables[factionKey] = playables[factionKey] + 1;
+			int playerId = m_playableManager.GetPlayerByPlayable(playable.GetRplId());
+			if (playerId > 0)
+			{
+				players[factionKey] = players[factionKey] + 1;
+			}
+			
+		}
+		if (currentFaction != "")
+			players[currentFaction] = players[currentFaction] - 1;
+		
+		//counting how much there are factons units compared to every unit
+		int playersCount = m_PlayerManager.GetPlayerCount();
+		foreach (FactionKey factionKey, int count: playables)
+		{	
+			desiredratio[factionKey] = count / playablesammount; 
+		}
+		//clamping avaivable over the ratio slots in proportion to current player count to ensure balance for small scenarios
+		int adjfactionsbalance = Math.Clamp(m_iFactionsBalance,1,(playersCount / 10));
+		
+		if (players[factionKeyPlayer] < 1)
+		{
+			//but we still want to get one player even in tiniest scenario
+			return true;
+		}
+		//check if that faction with a new player wouldnt get too many players
+		float ratio = (players[factionKeyPlayer] + 1 - adjfactionsbalance) / playersCount;
+		
+		return ratio <= desiredratio[factionKeyPlayer];
+	}	
+	
 };
+
+
+
+// partyzan minor edit. Ensure we have message which doesent rely on another addon. You can scrap that if you dont like that
+modded class PS_CharacterSelector : SCR_ButtonComponent
+{
+	override void OnClicked(SCR_ButtonBaseComponent button)
+	{
+		if (m_bStateClickSkip)
+		{
+			m_bStateClickSkip = false;
+			return;
+		}
+		
+		int playerId = m_CoopLobby.GetSelectedPlayer();
+		if (m_iPlayerId == -2)
+		{
+			m_CoopLobby.SetPreviewPlayable(m_iPlayableId, true);
+			AudioSystem.PlaySound("{C97850E4341F0CF9}Sounds/UI/Samples/Menu/UI_Button_Fail.wav");
+			return;
+		}
+		if (m_iPlayerId > 0 && playerId != m_iPlayerId)
+		{
+			m_CoopLobby.SetPreviewPlayable(m_iPlayableId, true);
+			AudioSystem.PlaySound("{C97850E4341F0CF9}Sounds/UI/Samples/Menu/UI_Button_Fail.wav");
+			return;
+		}
+		PS_PlayableContainer playableContainer = m_PlayableManager.GetPlayableById(m_iPlayableId);
+		if (playableContainer.GetDamageState() == EDamageState.DESTROYED)
+		{
+			m_CoopLobby.SetPreviewPlayable(m_iPlayableId, true);
+			AudioSystem.PlaySound("{C97850E4341F0CF9}Sounds/UI/Samples/Menu/UI_Button_Fail.wav");
+			return;
+		}
+	
+		SCR_EGameModeState gameState = m_GameModeCoop.GetState();
+		if (!PS_PlayersHelper.IsAdminOrServer())
+		{
+			RplId playableId = m_PlayableManager.GetPlayableByPlayer(m_iCurrentPlayerId);
+			if (gameState == SCR_EGameModeState.BRIEFING && playableId != RplId.Invalid())
+			{
+				m_CoopLobby.SetPreviewPlayable(m_iPlayableId, true);
+				return;
+			}
+		}
+		
+		
+		
+		if (playerId != m_iPlayerId)
+		{
+			if (!CanJoinFaction())
+			{
+				
+				SCR_ChatPanelManager chatPanelManager = SCR_ChatPanelManager.GetInstance();
+				ChatCommandInvoker invoker = chatPanelManager.GetCommandInvoker("lmsg");
+				invoker.Invoke(null, "Где баланс?");
+				SCR_ChatPanelManager.GetInstance().ShowHelpMessage("Соблюдайте баланс сторон");
+				m_CoopLobby.SetPreviewPlayable(m_iPlayableId, true);
+				return;
+			}
+			
+			AudioSystem.PlaySound("{9500A96BBA3B0581}Sounds/UI/Samples/Menu/UI_Gadget_Select.wav");
+			m_PlayableControllerComponent.MoveToVoNRoom(playerId, m_sFactionKey, m_sPlayableCallsign);
+			m_PlayableControllerComponent.ChangeFactionKey(playerId, m_sFactionKey);
+			m_PlayableControllerComponent.SetPlayerState(playerId, PS_EPlayableControllerState.NotReady);	
+			m_PlayableControllerComponent.SetPlayerPlayable(playerId, m_iPlayableId);
+		} else {
+			AudioSystem.PlaySound("{9500A96BBA3B0581}Sounds/UI/Samples/Menu/UI_Gadget_Select.wav");
+			m_PlayableControllerComponent.MoveToVoNRoom(playerId, m_sFactionKey, "#PS-VoNRoom_Faction");
+			m_PlayableControllerComponent.ChangeFactionKey(playerId, "");
+			m_PlayableControllerComponent.SetPlayerState(playerId, PS_EPlayableControllerState.NotReady);
+			m_PlayableControllerComponent.SetPlayerPlayable(playerId, RplId.Invalid());
+			if (PS_PlayersHelper.IsAdminOrServer())
+				m_PlayableControllerComponent.UnpinPlayer(playerId);
+		}
+		
+		if (PS_PlayersHelper.IsAdminOrServer() && playerId != m_iCurrentPlayerId && gameState == SCR_EGameModeState.GAME)
+			m_PlayableControllerComponent.ForceSwitch(playerId);
+		if (!PS_PlayersHelper.IsAdminOrServer() && playerId == m_iCurrentPlayerId && gameState == SCR_EGameModeState.BRIEFING)
+			m_PlayableControllerComponent.SwitchToMenuServer(SCR_EGameModeState.BRIEFING);
+	}
+	
+};
+
+
+// partyzan minor edit. there i start game on both factions declare ready while briefing
+modded class PS_PlayableManager : ScriptComponent
+{	
+	
+	// added another event. i dont know much of that stuff sorry
+	void StartTimeBriefing()
+	{
+		m_iStartTimerCounter -= 1;
+		Replication.BumpMe();
+		OnStartTimerCounterChanged();
+		Print("-+-timerbrifign: " + m_iStartTimerCounter);
+		if (m_iStartTimerCounter == 0)
+		{
+			PS_GameModeCoop gameModeCoop = PS_GameModeCoop.Cast(GetGame().GetGameMode());
+			gameModeCoop.AdvanceGameState(SCR_EGameModeState.BRIEFING);
+			GetGame().GetCallqueue().Remove(StartTimeBriefing);
+		}
+	}
+	
+	
+	override void SetFactionReady(FactionKey factionKey, int readyValue)
+	{
+		RPC_SetFactionReady(factionKey, readyValue);
+		Rpc(RPC_SetFactionReady, factionKey, readyValue);
+		
+		if (m_bFactionsReadySended)
+			return;
+		
+		array<int> players = {};
+		GetGame().GetPlayerManager().GetPlayers(players);
+		bool allFactionsReady = true;
+		foreach (int playerId : players)
+		{
+			factionKey = GetPlayerFactionKey(playerId);
+			if (factionKey == "")
+				continue;
+			if (m_mFactionReady[factionKey])
+				continue;
+			allFactionsReady = false;
+			break;
+		}
+		if (allFactionsReady)
+		{
+			m_bFactionsReadySended = true;
+			
+			SCR_ChatPanelManager chatPanelManager = SCR_ChatPanelManager.GetInstance();
+			ChatCommandInvoker invoker = chatPanelManager.GetCommandInvoker("tmsg");
+			invoker.Invoke(null, "Factions ready");
+			
+			SCR_ChatPanelManager.GetInstance().ShowHelpMessage("Factions ready");
+			///now we start countdown to stage advance
+			
+			m_iStartTimerCounter = 3;
+			GetGame().GetCallqueue().CallLater(StartTimeBriefing, 1000, true);
+			
+		}
+	}
+	
+};
+
+
+
+
+// 
+// ------==========  partyzans great code end  =================----------
+//
+
+
 
 class PS_QuickTvTMissionsConfig: JsonApiStruct
 {


### PR DESCRIPTION
игроки могут занимать слоты пропорционально соотношению юнитов стороны к общему. То есть если на миссии 15 игроков, а слотов 50 на 100, то можно будет занять только 5 на 10, при этом есть допуск в 1 игрока на каждые 10 человек, то есть может быть 6 на 10 или 10 на 14 а еще игра стартует с брифинга по готовности сторон